### PR TITLE
[build-catkin-project] Run tests

### DIFF
--- a/build-catkin-project/action.yml
+++ b/build-catkin-project/action.yml
@@ -74,5 +74,16 @@ runs:
         set +x
         . devel/setup.bash
         set -x
-        catkin build --limit-status-rate 0.1 -DCMAKE_BUILD_TYPE=${{ inputs.build-type }}  ${{ inputs.cmake-args }}
+        catkin build --limit-status-rate 0.1 -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }}
+      shell: bash
+    - name: Run test
+      run: |
+        set -e
+        set -x
+        cd ${GITHUB_WORKSPACE}/catkin_ws
+        set +x
+        . devel/setup.bash
+        set -x
+        catkin build --limit-status-rate 0.1 -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} --catkin-make-args run_tests ${{ inputs.cmake-args }}
+        catkin_test_results --verbose --all build
       shell: bash


### PR DESCRIPTION
See https://github.com/isri-aist/BaselineWalkingController/blob/a7756796de7c3e15ef297ab74c621ddbbe739d8e/.github/workflows/ci-catkin.yaml#L116-L125 for example.

The above code only tests the target ROS package. That should be enough (and could even be desirable to reduce time), but I couldn't get the target ROS package name in `build-catkin-project/action.yml`, so all package are tested in the code of this PR.