### PR TITLE
[build-catkin-project] Add an input catkin-packages

### DIFF
--- a/build-catkin-project/action.yml
+++ b/build-catkin-project/action.yml
@@ -17,6 +17,11 @@ inputs:
     required: true
     type: string
     default: ''
+  catkin-packages:
+    description: "Target catkin packages"
+    required: false
+    type: string
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -74,7 +79,7 @@ runs:
         set +x
         . devel/setup.bash
         set -x
-        catkin build --limit-status-rate 0.1 -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }}
+        catkin build --limit-status-rate 0.1 -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }} ${{ inputs.catkin-packages }}
       shell: bash
     - name: Run test
       run: |
@@ -84,6 +89,6 @@ runs:
         set +x
         . devel/setup.bash
         set -x
-        catkin build --limit-status-rate 0.1 -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} --catkin-make-args run_tests ${{ inputs.cmake-args }}
+        catkin build --limit-status-rate 0.1 -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} --catkin-make-args run_tests ${{ inputs.cmake-args }} ${{ inputs.catkin-packages }}
         catkin_test_results --verbose --all build
       shell: bash


### PR DESCRIPTION
See discussion in https://github.com/jrl-umi3218/github-actions/pull/33#issuecomment-1490049630

The `inputs.catkin-packages` is passed to both build and test commands (this is the same thing I originally did with CI). Feel free to edit the `description` as needed.