### PR TITLE
[build-catkin-project] Fix problem about inputs.catkin-packages for tests

### DIFF
--- a/build-catkin-project/action.yml
+++ b/build-catkin-project/action.yml
@@ -79,7 +79,7 @@ runs:
         set +x
         . devel/setup.bash
         set -x
-        catkin build --limit-status-rate 0.1 -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }} ${{ inputs.catkin-packages }}
+        catkin build --limit-status-rate 0.1 --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }} ${{ inputs.catkin-packages }}
       shell: bash
     - name: Run test
       run: |
@@ -89,6 +89,6 @@ runs:
         set +x
         . devel/setup.bash
         set -x
-        catkin build --limit-status-rate 0.1 -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} --catkin-make-args run_tests ${{ inputs.cmake-args }} ${{ inputs.catkin-packages }}
+        catkin build --limit-status-rate 0.1 --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }} --catkin-make-args run_tests ${{ inputs.catkin-packages }}
         catkin_test_results --verbose --all build
       shell: bash


### PR DESCRIPTION
Fixes a problem in https://github.com/jrl-umi3218/github-actions/pull/33  that `inputs.catkin-packages` is passed to `--catkin-make-args` instead of `--cmake-args`.

https://github.com/isri-aist/MultiContactController/actions/runs/4585938581/jobs/8098397356
```
--------------------------------------------------------------------------------
Additional CMake Args:       -DCMAKE_BUILD_TYPE=RelWithDebInfo
Additional Make Args:        None
Additional catkin Make Args: run_tests, -DINSTALL_DOCUMENTATION=true, -DENABLE_QLD=ON
Internal Make Job Server:    True
Cache Job Environments:      False
--------------------------------------------------------------------------------
```