### PR TITLE
[build-catkin-project] Re-order catkin build arguments

### DIFF
--- a/build-catkin-project/action.yml
+++ b/build-catkin-project/action.yml
@@ -17,6 +17,11 @@ inputs:
     required: true
     type: string
     default: ''
+  catkin-args:
+    description: "Extra catkin arguments"
+    required: false
+    type: string
+    default: ''
   build-packages:
     description: "Catkin packages to be built (default is all packages)"
     required: false
@@ -84,7 +89,7 @@ runs:
         set +x
         . devel/setup.bash
         set -x
-        catkin build ${{ inputs.build-packages }} --limit-status-rate 0.1 --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }}
+        catkin build ${{ inputs.build-packages }} --limit-status-rate 0.1 ${{ inputs.catkin-args }} --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }}
       shell: bash
     - name: Run test
       run: |
@@ -94,6 +99,6 @@ runs:
         set +x
         . devel/setup.bash
         set -x
-        catkin build ${{ inputs.test-packages }} --limit-status-rate 0.1 --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }} --catkin-make-args run_tests
+        catkin build ${{ inputs.test-packages }} --limit-status-rate 0.1 ${{ inputs.catkin-args }} --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }} --catkin-make-args run_tests
         catkin_test_results --verbose --all build
       shell: bash

--- a/build-catkin-project/action.yml
+++ b/build-catkin-project/action.yml
@@ -17,8 +17,13 @@ inputs:
     required: true
     type: string
     default: ''
-  catkin-packages:
-    description: "Target catkin packages"
+  build-packages:
+    description: "Catkin packages to be built (default is all packages)"
+    required: false
+    type: string
+    default: ''
+  test-packages:
+    description: "Catkin package to be tested (default is all packages)"
     required: false
     type: string
     default: ''
@@ -79,7 +84,7 @@ runs:
         set +x
         . devel/setup.bash
         set -x
-        catkin build --limit-status-rate 0.1 --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }} ${{ inputs.catkin-packages }}
+        catkin build ${{ inputs.build-packages }} --limit-status-rate 0.1 --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }}
       shell: bash
     - name: Run test
       run: |
@@ -89,6 +94,6 @@ runs:
         set +x
         . devel/setup.bash
         set -x
-        catkin build --limit-status-rate 0.1 --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }} --catkin-make-args run_tests ${{ inputs.catkin-packages }}
+        catkin build ${{ inputs.test-packages }} --limit-status-rate 0.1 --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }} --catkin-make-args run_tests
         catkin_test_results --verbose --all build
       shell: bash


### PR DESCRIPTION
- Re-order catkin build arguments so that target packages are handled correctly, which fixes the problem with the changes on https://github.com/jrl-umi3218/github-actions/pull/34 . See [this](https://github.com/isri-aist/LocomanipController/actions/runs/4773082042) for an example of a CI failure in this regard.
- Allow target packages to be specified for build and test, respectively

