### PR TITLE
[build-catkin-project] Separate catkin-args into catkin-build-args and catkin-test-args

### DIFF
--- a/build-catkin-project/action.yml
+++ b/build-catkin-project/action.yml
@@ -17,8 +17,13 @@ inputs:
     required: true
     type: string
     default: ''
-  catkin-args:
-    description: "Extra catkin arguments"
+  catkin-build-args:
+    description: "Extra catkin arguments for build"
+    required: false
+    type: string
+    default: ''
+  catkin-test-args:
+    description: "Extra catkin arguments for test"
     required: false
     type: string
     default: ''
@@ -89,7 +94,7 @@ runs:
         set +x
         . devel/setup.bash
         set -x
-        catkin build ${{ inputs.build-packages }} --limit-status-rate 0.1 ${{ inputs.catkin-args }} --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }}
+        catkin build ${{ inputs.build-packages }} --limit-status-rate 0.1 ${{ inputs.catkin-build-args }} --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }}
       shell: bash
     - name: Run test
       run: |
@@ -99,6 +104,6 @@ runs:
         set +x
         . devel/setup.bash
         set -x
-        catkin build ${{ inputs.test-packages }} --limit-status-rate 0.1 ${{ inputs.catkin-args }} --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }} --catkin-make-args run_tests
+        catkin build ${{ inputs.test-packages }} --limit-status-rate 0.1 ${{ inputs.catkin-test-args }} --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }} --catkin-make-args run_tests
         catkin_test_results --verbose --all build
       shell: bash


### PR DESCRIPTION
This is necessary to shorten the CI time by building all dependent packages in the build phase and testing only the packages of interest in the test phase (by setting `catkin-build-args` to empty and `catkin-test-args` to `--no-deps`).