### PR TITLE
[build-catkin-project] Add input options to skip test

### DIFF
--- a/build-catkin-project/action.yml
+++ b/build-catkin-project/action.yml
@@ -37,6 +37,11 @@ inputs:
     required: false
     type: string
     default: ''
+  skip-test:
+    description: "Whether to skip test"
+    required: false
+    type: boolean
+    default: false
 runs:
   using: "composite"
   steps:
@@ -97,6 +102,7 @@ runs:
         catkin build ${{ inputs.build-packages }} --limit-status-rate 0.1 ${{ inputs.catkin-build-args }} --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }}
       shell: bash
     - name: Run test
+      if: ${{ !inputs.skip-test }}
       run: |
         set -e
         set -x


### PR DESCRIPTION
Use case for this patch:
In the rviz plugin package, I intend to skip the test in this step in the CI and call the test manually in the next step with the display settings.
https://github.com/mmurooka/RobotArrayVisualization/tree/main/robot_array_rviz_plugins
(It is private now, but will become public soon.)