### PR TITLE
[build-catkin-project] Fix variable handling in the 'if' condition

### DIFF
--- a/build-catkin-project/action.yml
+++ b/build-catkin-project/action.yml
@@ -102,7 +102,7 @@ runs:
         catkin build ${{ inputs.build-packages }} --limit-status-rate 0.1 ${{ inputs.catkin-build-args }} --cmake-args -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ inputs.cmake-args }}
       shell: bash
     - name: Run test
-      if: ${{ !inputs.skip-test }}
+      if: ${{ inputs.skip-test == false || inputs.skip-test == 'false' }}
       run: |
         set -e
         set -x


### PR DESCRIPTION
See https://github.com/jrl-umi3218/github-actions/pull/45#issuecomment-1874040745

This seems to be a common pitfall discussed in https://github.com/actions/runner/issues/1483  .
The workaround https://github.com/actions/runner/issues/1483#issuecomment-1856724561 is employed.