### PR TITLE
:+1: update ros2 version for linux distro

### DIFF
--- a/install-dependencies/index.js
+++ b/install-dependencies/index.js
@@ -34,7 +34,11 @@ async function get_ros_distro()
   }
   if(dist_name == 'jammy')
   {
-    return [true, 'iron'];
+    return [true, 'humble'];
+  }
+  if(dist_name == 'noble')
+  {
+    return [true, 'jazzy'];
   }
   core.setFailed(`Cannot determine ROS distro for Linux distro: ${dist_name}`);
 }


### PR DESCRIPTION
According to ROS2 documentation, ROS2 Iron is going to EOL from next month (EOL November 2024) while ROS2 Humble's EOL is March 2027. Therefore, for Jammy Ubuntu 22.04, Humble is better option. 
https://docs.ros.org/en/iron/Releases.html
Also, for Noble Ubuntu 24.04, Jazzy should be included
