### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4.1.7 in /.github/workflows"

### DIFF
--- a/.github/workflows/package-project.yml
+++ b/.github/workflows/package-project.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Download packages
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v3
       with:
         name: packages-${{ matrix.dist }}-${{ matrix.arch }}
         path: packages-${{ matrix.dist }}-${{ matrix.arch }}


### PR DESCRIPTION
Reverts jrl-umi3218/github-actions#47

Due to modification made on upload-artifact from artifact v3 and v4. This upgrade cannot be applied straight forward. 

See following issue for more details : [https://github.com/actions/upload-artifact/issues/478](https://github.com/actions/upload-artifact/issues/478)