### PR TITLE
Add a reusable workflow for releasing docker images/devcontainers of mc-rtc-superbuild

### DIFF
--- a/.github/workflows/superbuild-devcontainer.yml
+++ b/.github/workflows/superbuild-devcontainer.yml
@@ -1,3 +1,16 @@
+# This reusable workflow builds and publishes Docker images for mc-rtc-superbuild in three variants:
+#
+# 1. standalone-release: Minimal production image (~2-4GB) with install files + catkin workspaces
+#    - Use case: Running controllers/simulators in production environments
+#
+# 2. standalone-devel: Full development image (~10-20GB) with sources + build + install + ccache
+#    - Use case: Complete reproducible development environment with all build artifacts
+#
+# 3. devcontainer: VS Code devcontainer image (~1-2GB) with system packages + ccache
+#    - Use case: Development with mounted source code and fast incremental builds
+#
+# The workflow optimizes build times by sharing the expensive build stage between standalone variants.
+
 name: mc-rtc-superbuild packaging with Docker/Devcontainer
 
 on:
@@ -25,7 +38,7 @@ on:
         default: ''
         description: 'Space-separated list of build-arg for docker. Ex "BUILD_VERSION=standalone KEEP_INSTALL=false"'
 
-      build-standalone:
+      build-standalone-release:
         type: boolean
         required: false
         default: true
@@ -67,7 +80,6 @@ on:
         required: false
         default: true
         description: "Whether to push to the container-repository"
-
 
     secrets:
       SSH_KEY:
@@ -169,20 +181,19 @@ jobs:
         echo "CMAKE_PRESET=$CMAKE_PRESET" >> $GITHUB_ENV
         echo "UBUNTU_VERSION=${{ matrix.os }}" >> $GITHUB_ENV
 
-    - name: 'Docker: Build Standalone Release'
-      if: ${{ inputs.build-standalone }}
+    - name: 'Docker: Build Standalone Images (Release + Devel)'
+      if: ${{ inputs.build-standalone-release || inputs.build-standalone-devel }}
       env:
-        CONTAINER_TAG: ${{ matrix.os }}-standalone-${{ env.RELEASE_TAG }}
+        CONTAINER_TAG_RELEASE: ${{ matrix.os }}-standalone-release-${{ env.RELEASE_TAG }}
+        CONTAINER_TAG_DEVEL: ${{ matrix.os }}-standalone-devel-${{ env.RELEASE_TAG }}
       shell: bash
       run: |
         echo "::group::Prepare docker"
 
-        CONTAINER_FULL_NAME=$CONTAINER_NAME:$CONTAINER_TAG
-        echo "CONTAINER_FULL_NAME=$CONTAINER_FULL_NAME" >> $GITHUB_ENV
-        echo "::endgroup::"
-
-        echo "::group::Print Dockerfile"
-        cat .github/devcontainer/Dockerfile
+        CONTAINER_FULL_NAME_RELEASE=$CONTAINER_NAME:$CONTAINER_TAG_RELEASE
+        CONTAINER_FULL_NAME_DEVEL=$CONTAINER_NAME:$CONTAINER_TAG_DEVEL
+        echo "CONTAINER_FULL_NAME_RELEASE=$CONTAINER_FULL_NAME_RELEASE" >> $GITHUB_ENV
+        echo "CONTAINER_FULL_NAME_DEVEL=$CONTAINER_FULL_NAME_DEVEL" >> $GITHUB_ENV
         echo "::endgroup::"
 
         echo "::group::Configuring build-args"
@@ -194,56 +205,51 @@ jobs:
           BUILD_ARGS="$BUILD_ARGS --build-arg $arg"
         done
         echo "Extra build args: $BUILD_ARGS"
-        echo "BUILD_ARGS=$BUILD_ARGS" >> $GITHUB_ENV
         echo "::endgroup::"
 
-        echo "::group::Build Dockerfile"
-        docker build . -f .github/devcontainer/Dockerfile $SSH_OPT --tag $CONTAINER_FULL_NAME --build-arg CMAKE_PRESET=$CMAKE_PRESET --build-arg BUILD_VERSION=standalone --build-arg UBUNTU_VERSION="${{ matrix.os }}" $BUILD_ARGS
+        echo "::group::Build Standalone Release Image"
+        if [ "${{ inputs.build-standalone-release }}" = "true" ]; then
+          docker build . -f .github/devcontainer/Dockerfile $SSH_OPT \
+            --tag $CONTAINER_FULL_NAME_RELEASE \
+            --target standalone-release \
+            --build-arg CMAKE_PRESET=$CMAKE_PRESET \
+            --build-arg BUILD_VERSION=standalone \
+            --build-arg UBUNTU_VERSION="${{ matrix.os }}" \
+            $BUILD_ARGS
+
+          echo "Standalone Release image size:"
+          docker inspect -f "{{ .Size }}" $CONTAINER_FULL_NAME_RELEASE | numfmt --to=si
+        fi
         echo "::endgroup::"
 
-        echo "::group::Check docker image size"
-        docker inspect -f "{{ .Size }}" $CONTAINER_FULL_NAME | numfmt --to=si
+        echo "::group::Build Standalone Devel Image"
+        if [ "${{ inputs.build-standalone-devel }}" = "true" ]; then
+          docker build . -f .github/devcontainer/Dockerfile $SSH_OPT \
+            --tag $CONTAINER_FULL_NAME_DEVEL \
+            --target standalone-devel \
+            --build-arg CMAKE_PRESET=$CMAKE_PRESET \
+            --build-arg BUILD_VERSION=standalone \
+            --build-arg UBUNTU_VERSION="${{ matrix.os }}" \
+            $BUILD_ARGS
+
+          echo "Standalone Devel image size:"
+          docker inspect -f "{{ .Size }}" $CONTAINER_FULL_NAME_DEVEL | numfmt --to=si
+        fi
         echo "::endgroup::"
 
-    - name: 'Docker: Push Standalone Release (public repositories)'
-      if: ${{ inputs.build-standalone && inputs.push }}
+    - name: 'Docker: Push Standalone Images'
+      if: ${{ (inputs.build-standalone-release || inputs.build-standalone-devel) && inputs.push }}
       shell: bash
       run: |
-        docker push $CONTAINER_FULL_NAME
+        if [ "${{ inputs.build-standalone-release }}" = "true" ]; then
+          echo "Pushing standalone-release image..."
+          docker push $CONTAINER_FULL_NAME_RELEASE
+        fi
 
-    - name: Free Disk Space (Ubuntu)
-      if: ${{ inputs.free-disk-space && inputs.build-devcontainer}}
-      uses: jlumbroso/free-disk-space@main
-
-    - name: 'Docker: Build Standalone Devel'
-      if: ${{ inputs.build-standalone-devel }}
-      env:
-        CONTAINER_TAG: ${{ matrix.os }}-standalone-devel-${{ env.RELEASE_TAG }}
-      shell: bash
-      run: |
-        echo "::group::Prepare docker"
-
-        CONTAINER_FULL_NAME_DEVEL=$CONTAINER_NAME:$CONTAINER_TAG
-        echo "CONTAINER_FULL_NAME_DEVEL=$CONTAINER_FULL_NAME_DEVEL" >> $GITHUB_ENV
-        echo "::endgroup::"
-
-        echo "::group::Print Dockerfile"
-        cat .github/devcontainer/Dockerfile
-        echo "::endgroup::"
-
-        echo "::group::Build Dockerfile"
-        docker build . -f .github/devcontainer/Dockerfile $SSH_OPT --tag $CONTAINER_FULL_NAME_DEVEL --build-arg CMAKE_PRESET=$CMAKE_PRESET --build-arg BUILD_VERSION=standalone-devel --build-arg UBUNTU_VERSION="${{ matrix.os }}" $BUILD_ARGS
-        echo "::endgroup::"
-
-        echo "::group::Check docker image size"
-        docker inspect -f "{{ .Size }}" $CONTAINER_FULL_NAME_DEVEL | numfmt --to=si
-        echo "::endgroup::"
-
-    - name: 'Docker: Push Standalone Devel (public repositories)'
-      if: ${{ inputs.build-standalone-devel && inputs.push }}
-      shell: bash
-      run: |
-        docker push $CONTAINER_FULL_NAME_DEVEL
+        if [ "${{ inputs.build-standalone-devel }}" = "true" ]; then
+          echo "Pushing standalone-devel image..."
+          docker push $CONTAINER_FULL_NAME_DEVEL
+        fi
 
     - name: Free Disk Space (Ubuntu)
       if: ${{ inputs.free-disk-space && inputs.build-devcontainer}}
@@ -270,27 +276,32 @@ jobs:
         echo "DEVCONTAINER_NAME=${{ inputs.container-repository }}" >> $GITHUB_ENV
         echo "DEVCONTAINER_TAG=${{ matrix.os }}-devcontainer-${{ env.RELEASE_TAG }}" >> $GITHUB_ENV
         echo "DEVCONTAINER_FULL_NAME=$CONTAINER_NAME:${{ matrix.os }}-devcontainer-${{ env.RELEASE_TAG }}" >> $GITHUB_ENV
-        echo "BUILD_VERSION=devcontainer" >> $GITHUB_ENV
-        if [ "${{ env.SSH_KEY }}" != '' ]; then
-          SSH_OPT="--ssh=default"
-          echo "SSH_OPT=$SSH_OPT"
-          echo "SSH_OPT=$SSH_OPT" >> $GITHUB_ENV;
-        fi
 
-    - name: Build and push dev container image
-      if: ${{ inputs.build-devcontainer }}
-      uses: devcontainers/ci@v0.3
-      with:
-        imageName: ${{ env.DEVCONTAINER_NAME}}
-        imageTag: ${{ env.DEVCONTAINER_TAG }}
-        subFolder: .github/devcontainer/${{ matrix.os }}
-        configFile: .github/devcontainer/${{ matrix.os }}/devcontainer.json
-        push: ${{ inputs.push && 'always' || 'never' }}
-
-    - name: 'Docker: Check devcontainer size'
+    - name: 'Docker: Build Devcontainer Image'
       if: ${{ inputs.build-devcontainer }}
       shell: bash
       run: |
-        docker images
-        docker ps
+        echo "::group::Build Devcontainer Image"
+        docker build . -f .github/devcontainer/Dockerfile $SSH_OPT \
+          --tag $DEVCONTAINER_FULL_NAME \
+          --target devcontainer \
+          --build-arg CMAKE_PRESET=$CMAKE_PRESET \
+          --build-arg BUILD_VERSION=devcontainer \
+          --build-arg UBUNTU_VERSION="${{ matrix.os }}"
+
+        echo "Devcontainer image size:"
         docker inspect -f "{{ .Size }}" $DEVCONTAINER_FULL_NAME | numfmt --to=si
+        echo "::endgroup::"
+
+    - name: 'Docker: Push Devcontainer Image'
+      if: ${{ inputs.build-devcontainer && inputs.push }}
+      shell: bash
+      run: |
+        echo "Pushing devcontainer image..."
+        docker push $DEVCONTAINER_FULL_NAME
+
+    - name: 'Docker: Check all image sizes'
+      shell: bash
+      run: |
+        echo "All built images:"
+        docker images

--- a/.github/workflows/superbuild-devcontainer.yml
+++ b/.github/workflows/superbuild-devcontainer.yml
@@ -221,7 +221,12 @@ jobs:
         echo "::group::Configuring build-args"
         BUILD_ARGS=""
         if [ ${{ inputs.custom-entrypoint-standalone }} != '' ]; then
-          BUILD_ARGS="--build-arg CUSTOM_ENTRYPOINT=${{ inputs.custom-entrypoint-standalone }}"
+          # CUSTOM_ENTRYPOINT="${{ github.workspace }}/${{ inputs.custom-entrypoint-standalone }}"
+          CUSTOM_ENTRYPOINT="${{ inputs.custom-entrypoint-standalone }}"
+          echo "CUSTOM_ENTRYPOINT: $CUSTOM_ENTRYPOINT"
+          cat $CUSTOM_ENTRYPOINT
+          pwd
+          BUILD_ARGS="--build-arg CUSTOM_ENTRYPOINT=$CUSTOM_ENTRYPOINT"
         fi
         for arg in ${{ inputs.build-args }}; do
           BUILD_ARGS="$BUILD_ARGS --build-arg $arg"

--- a/.github/workflows/superbuild-devcontainer.yml
+++ b/.github/workflows/superbuild-devcontainer.yml
@@ -78,6 +78,11 @@ on:
         required: false
         default: true
 
+      image-source-repo:
+        type: string
+        required: false
+        description: "The repository to which this image is linked. Only affect the image labels."
+
       repository:
         type: string
         description: "path to the superbuild repository to clone and package"
@@ -208,6 +213,7 @@ jobs:
       env:
         CONTAINER_TAG_RELEASE: ${{ env.TAG_NAME_PREFIX }}${{ inputs.os }}-standalone-release-${{ env.TAG_SUFFIX }}
         CONTAINER_TAG_DEVEL: ${{ env.TAG_NAME_PREFIX }}${{ inputs.os }}-standalone-devel-${{ env.TAG_SUFFIX }}
+        IMAGE_SOURCE_REPO: ${{ inputs.image-source-repo && inputs.image-source-repo || github.repository  }}
       shell: bash
       run: |
         echo "::group::Prepare docker"
@@ -219,7 +225,9 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Configuring build-args"
-        BUILD_ARGS=""
+
+        echo "IMAGE_SOURCE_REPO=$IMAGE_SOURCE_REPO" >> $GITHUB_ENV
+        BUILD_ARGS="--build-arg IMAGE_SOURCE_REPO=$IMAGE_SOURCE_REPO"
         if [ ${{ inputs.custom-entrypoint-standalone }} != '' ]; then
           # CUSTOM_ENTRYPOINT="${{ github.workspace }}/${{ inputs.custom-entrypoint-standalone }}"
           CUSTOM_ENTRYPOINT="${{ inputs.custom-entrypoint-standalone }}"
@@ -325,7 +333,8 @@ jobs:
           --target devcontainer \
           --build-arg CMAKE_PRESET=$CMAKE_PRESET \
           --build-arg BUILD_VERSION=devcontainer \
-          --build-arg UBUNTU_VERSION="${{ inputs.os }}"
+          --build-arg UBUNTU_VERSION="${{ inputs.os }}" \
+          --build-arg IMAGE_SOURCE_REPO=$IMAGE_SOURCE_REPO
 
         echo "Devcontainer image size:"
         docker inspect -f "{{ .Size }}" $DEVCONTAINER_FULL_NAME | numfmt --to=si

--- a/.github/workflows/superbuild-devcontainer.yml
+++ b/.github/workflows/superbuild-devcontainer.yml
@@ -33,6 +33,18 @@ on:
         required: false
         default: relwithdebinfo
 
+      release-tag:
+        type: string
+        required: false
+        default: ''
+        description: "Release tag to use for the job. If not specified, 'latest' will be used."
+
+      tag-name-prefix:
+        type: string
+        required: false
+        default: ''
+        description: "Prefix for the container tag. This can be used to distiguish different containers published to the same container registry. For example you could build several demos with different presets and use this prefix to distinguish them. The tag will be of the form: <tag-name-prefix>-<preset>-<os>-<release-tag>"
+
       include-preset-in-name:
         type: boolean
         required: false
@@ -150,9 +162,9 @@ jobs:
     - name: Check release
       shell: bash
       run: |
-        if [ -n "${{ github.event.client_payload.tag }}" ]; then
-          echo "This is a release, using version tag ${{ github.event.client_payload.tag }}"
-          echo "RELEASE_TAG=${{ github.event.client_payload.tag }}" >> $GITHUB_ENV
+        if [ -n "${{ inputs.release-tag }}" ]; then
+          echo "This is a release, using version tag ${{ inputs.release-tag }}"
+          echo "RELEASE_TAG=${{ inputs.release-tag }}" >> $GITHUB_ENV
         else
           echo "This is not a release, using latest tag"
           echo "RELEASE_TAG=latest" >> $GITHUB_ENV
@@ -189,12 +201,13 @@ jobs:
           TAG_SUFFIX="$CMAKE_PRESET-$TAG_SUFFIX"
         fi
         echo "TAG_SUFFIX=$TAG_SUFFIX" >> $GITHUB_ENV
+        echo "TAG_NAME_PREFIX=${{ inputs.tag-name-prefix }}${{ inputs.tag-name-prefix && '-' || '' }}" >> $GITHUB_ENV
 
     - name: 'Docker: Build Standalone Images (Release + Devel)'
       if: ${{ inputs.build-standalone-release || inputs.build-standalone-devel }}
       env:
-        CONTAINER_TAG_RELEASE: ${{ inputs.os }}-standalone-release-${{ env.TAG_SUFFIX }}
-        CONTAINER_TAG_DEVEL: ${{ inputs.os }}-standalone-devel-${{ env.TAG_SUFFIX }}
+        CONTAINER_TAG_RELEASE: ${{ env.TAG_NAME_PREFIX }}${{ inputs.os }}-standalone-release-${{ env.TAG_SUFFIX }}
+        CONTAINER_TAG_DEVEL: ${{ env.TAG_NAME_PREFIX }}${{ inputs.os }}-standalone-devel-${{ env.TAG_SUFFIX }}
       shell: bash
       run: |
         echo "::group::Prepare docker"
@@ -294,7 +307,7 @@ jobs:
       shell: bash
       run: |
         echo "DEVCONTAINER_NAME=${{ inputs.container-repository }}" >> $GITHUB_ENV
-        echo "DEVCONTAINER_TAG=${{ inputs.os }}-devcontainer-${{ env.TAG_SUFFIX }}" >> $GITHUB_ENV
+        echo "DEVCONTAINER_TAG=${{ env.TAG_NAME_PREFIX }}${{ inputs.os }}-devcontainer-${{ env.TAG_SUFFIX }}" >> $GITHUB_ENV
         echo "DEVCONTAINER_FULL_NAME=$CONTAINER_NAME:${{ inputs.os }}-devcontainer-${{ env.TAG_SUFFIX }}" >> $GITHUB_ENV
 
     - name: 'Docker: Build Devcontainer Image'

--- a/.github/workflows/superbuild-devcontainer.yml
+++ b/.github/workflows/superbuild-devcontainer.yml
@@ -21,6 +21,13 @@ on:
         type: string
         default: ubuntu-24.04
         description: "Runner to use for the job."
+
+      os:
+        type: string
+        required: false
+        default: jammy
+        description: "Ubuntu version to use for the job. Supported values: jammy, noble"
+
       preset:
         type: string
         required: false
@@ -98,11 +105,6 @@ jobs:
       contents: read
       packages: write
     runs-on: ${{ inputs.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # os: [jammy, noble]
-        os: [jammy]
     env:
       SSH_KEY: ${{ secrets.SSH_KEY }}
 
@@ -177,16 +179,10 @@ jobs:
           echo "SSH_OPT=$SSH_OPT" >> $GITHUB_ENV;
         fi
         CMAKE_PRESET="${{ inputs.preset }}"
-        if [ "${{ matrix.os }}" = "noble" ]; then
-          echo "os is noble"
-          CMAKE_PRESET=relwithdebinfo-noble
-        else
-          echo "os is not noble"
-        fi
         echo "CMAKE_PRESET: $CMAKE_PRESET"
         echo "CMAKE_PRESET=$CMAKE_PRESET" >> $GITHUB_ENV
-        echo "UBUNTU_VERSION=${{ matrix.os }}" >> $GITHUB_ENV
-        
+        echo "UBUNTU_VERSION=${{ inputs.os }}" >> $GITHUB_ENV
+
         # Create tag suffix with optional preset inclusion
         TAG_SUFFIX="${{ env.RELEASE_TAG }}"
         if [ "${{ inputs.include-preset-in-name }}" = "true" ]; then
@@ -197,8 +193,8 @@ jobs:
     - name: 'Docker: Build Standalone Images (Release + Devel)'
       if: ${{ inputs.build-standalone-release || inputs.build-standalone-devel }}
       env:
-        CONTAINER_TAG_RELEASE: ${{ matrix.os }}-standalone-release-${{ env.TAG_SUFFIX }}
-        CONTAINER_TAG_DEVEL: ${{ matrix.os }}-standalone-devel-${{ env.TAG_SUFFIX }}
+        CONTAINER_TAG_RELEASE: ${{ inputs.os }}-standalone-release-${{ env.TAG_SUFFIX }}
+        CONTAINER_TAG_DEVEL: ${{ inputs.os }}-standalone-devel-${{ env.TAG_SUFFIX }}
       shell: bash
       run: |
         echo "::group::Prepare docker"
@@ -227,7 +223,7 @@ jobs:
             --target standalone-release \
             --build-arg CMAKE_PRESET=$CMAKE_PRESET \
             --build-arg BUILD_VERSION=standalone \
-            --build-arg UBUNTU_VERSION="${{ matrix.os }}" \
+            --build-arg UBUNTU_VERSION="${{ inputs.os }}" \
             $BUILD_ARGS
 
           echo "Standalone Release image size:"
@@ -242,7 +238,7 @@ jobs:
             --target standalone-devel \
             --build-arg CMAKE_PRESET=$CMAKE_PRESET \
             --build-arg BUILD_VERSION=standalone \
-            --build-arg UBUNTU_VERSION="${{ matrix.os }}" \
+            --build-arg UBUNTU_VERSION="${{ inputs.os }}" \
             $BUILD_ARGS
 
           echo "Standalone Devel image size:"
@@ -288,8 +284,8 @@ jobs:
       shell: bash
       run: |
         echo "DEVCONTAINER_NAME=${{ inputs.container-repository }}" >> $GITHUB_ENV
-        echo "DEVCONTAINER_TAG=${{ matrix.os }}-devcontainer-${{ env.TAG_SUFFIX }}" >> $GITHUB_ENV
-        echo "DEVCONTAINER_FULL_NAME=$CONTAINER_NAME:${{ matrix.os }}-devcontainer-${{ env.TAG_SUFFIX }}" >> $GITHUB_ENV
+        echo "DEVCONTAINER_TAG=${{ inputs.os }}-devcontainer-${{ env.TAG_SUFFIX }}" >> $GITHUB_ENV
+        echo "DEVCONTAINER_FULL_NAME=$CONTAINER_NAME:${{ inputs.os }}-devcontainer-${{ env.TAG_SUFFIX }}" >> $GITHUB_ENV
 
     - name: 'Docker: Build Devcontainer Image'
       if: ${{ inputs.build-devcontainer }}
@@ -301,7 +297,7 @@ jobs:
           --target devcontainer \
           --build-arg CMAKE_PRESET=$CMAKE_PRESET \
           --build-arg BUILD_VERSION=devcontainer \
-          --build-arg UBUNTU_VERSION="${{ matrix.os }}"
+          --build-arg UBUNTU_VERSION="${{ inputs.os }}"
 
         echo "Devcontainer image size:"
         docker inspect -f "{{ .Size }}" $DEVCONTAINER_FULL_NAME | numfmt --to=si

--- a/.github/workflows/superbuild-devcontainer.yml
+++ b/.github/workflows/superbuild-devcontainer.yml
@@ -265,6 +265,16 @@ jobs:
       if: ${{ inputs.free-disk-space && inputs.build-devcontainer}}
       uses: jlumbroso/free-disk-space@main
 
+    - name: Clean Docker before devcontainer build
+      if: ${{ inputs.free-disk-space && inputs.build-devcontainer }}
+      shell: bash
+      run: |
+        echo "Pruning unused Docker resources..."
+        docker system prune -af || true
+        docker builder prune -af || true
+        docker image prune -af || true
+        docker volume prune -f || true
+
     - name: Setup Node.js
       if: ${{ inputs.build-devcontainer }}
       uses: actions/setup-node@v4

--- a/.github/workflows/superbuild-devcontainer.yml
+++ b/.github/workflows/superbuild-devcontainer.yml
@@ -1,0 +1,258 @@
+name: mc-rtc-superbuild packaging with Docker/Devcontainer
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-24.04
+        description: "Runner to use for the job."
+      preset:
+        type: string
+        required: false
+        default: relwithdebinfo
+
+      custom-entrypoint-standalone:
+        type: string
+        required: false
+        default: ''
+        description: 'Path to a custom entrypoint script to include in the standalone image'
+
+      build-args:
+        type: string
+        required: false
+        default: ''
+        description: 'Space-separated list of build-arg for docker. Ex "BUILD_VERSION=standalone KEEP_INSTALL=false"'
+
+      repository:
+        type: string
+        description: "path to the superbuild repository to clone and package"
+        required: false
+        default: ''
+
+      branch:
+        type: string
+        description: "superbuild branch to use"
+        default: ''
+        required: false
+
+      free-disk-space:
+        type: boolean
+        required: false
+        default: false
+
+      container-repository:
+        type: string
+        required: true
+        description: "Full path the the github container registry package path: ghcr.io/mc-rtc/mc-rtc-superbuild"
+
+      push:
+        type: boolean
+        required: false
+        default: true
+        description: "Whether to push to the container-repository"
+
+
+    secrets:
+      SSH_KEY:
+        description: "Private ssh key with access to clone the private repositories specified in the superbuild"
+        required: false
+
+jobs:
+  reusable_workflow_job:
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ${{ inputs.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [jammy, noble]
+    env:
+      SSH_KEY: ${{ secrets.SSH_KEY }}
+
+    steps:
+    - name: Dump github context
+      env:
+       GITHUB_CONTEXT: ${{ toJson(github) }}
+      shell: bash
+      run: |
+        echo "$GITHUB_CONTEXT"
+
+    # Configures ssh-agent if SSH_KEY secret exists
+    - name: Configure ssh-agent
+      if: ${{ env.SSH_KEY != '' }}
+      uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ secrets.SSH_KEY }}
+
+    - name: Check ssh-agent
+      if: ${{ env.SSH_KEY != '' }}
+      shell: bash
+      run: |
+          echo "SSH_AUTH_SOCK = ${{ env.SSH_AUTH_SOCK }}"
+          ssh-add -l
+
+    - name: Free Disk Space (Ubuntu)
+      if: ${{ inputs.free-disk-space }}
+      uses: jlumbroso/free-disk-space@main
+
+    - name: Clone superbuild repository
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.branch }}
+        ssh-key: ${{ env.SSH_KEY }}
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 'latest'
+
+    - name: Upgrade NPM
+      shell: bash
+      run: npm install -g npm@latest
+
+    - name: Check NPM Version
+      run: npm -v
+
+    - name: Check docker
+      shell: bash
+      run: |
+          docker ps
+
+    - name: Check release
+      shell: bash
+      run: |
+        if [ -n "${{ github.event.client_payload.tag }}" ]; then
+          echo "This is a release, using version tag ${{ github.event.client_payload.tag }}"
+          echo "RELEASE_TAG=${{ github.event.client_payload.tag }}" >> $GITHUB_ENV
+        else
+          echo "This is not a release, using latest tag"
+          echo "RELEASE_TAG=latest" >> $GITHUB_ENV
+        fi
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: 'Docker: Build Standalone Release'
+      env:
+        CONTAINER_NAME: ${{ inputs.container-repository }}
+        CONTAINER_TAG: ${{ matrix.os }}-standalone-${{ env.RELEASE_TAG }}
+      shell: bash
+      run: |
+        echo "::group::Prepare docker"
+        CMAKE_PRESET="${{ inputs.preset }}"
+        if [ "${{ matrix.os }}" = "noble" ]; then
+          echo "os is noble"
+          CMAKE_PRESET=relwithdebinfo-noble
+        else
+          echo "os is not noble"
+        fi
+        echo "CMAKE_PRESET: $CMAKE_PRESET"
+        echo "CMAKE_PRESET=$CMAKE_PRESET" >> $GITHUB_ENV
+
+        if [ "${{ env.SSH_KEY }}" != '' ]; then
+          SSH_OPT='--ssh default'
+          echo "SSH_OPT=$SSH_OPT"
+          echo "SSH_OPT='--ssh default'" >> $GITHUB_ENV;
+        fi
+        echo "CONTAINER_NAME: $CONTAINER_NAME"
+        echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
+        CONTAINER_FULL_NAME=$CONTAINER_NAME:$CONTAINER_TAG
+        echo "CONTAINER_FULL_NAME=$CONTAINER_FULL_NAME" >> $GITHUB_ENV
+        echo "::endgroup::"
+
+        echo "::group::Print Dockerfile"
+        cat .github/devcontainer/Dockerfile
+        echo "::endgroup::"
+
+        echo "::group::Configuring build-args"
+        BUILD_ARGS=""
+        if [ ${{ inputs.custom-entrypoint-standalone }} != '' ]; then
+          BUILD_ARGS="--build-arg CUSTOM_ENTRYPOINT=${{ inputs.custom-entrypoint-standalone }}"
+        fi
+        for arg in ${{ inputs.build-args }}; do
+          BUILD_ARGS="$BUILD_ARGS --build-arg $arg"
+        done
+        echo "Extra build args: $BUILD_ARGS"
+        echo "BUILD_ARGS=$BUILD_ARGS" >> $GITHUB_ENV
+        echo "::endgroup::"
+
+        echo "::group::Build Dockerfile"
+        docker build . -f .github/devcontainer/Dockerfile $SSH_OPT --tag $CONTAINER_FULL_NAME --build-arg CMAKE_PRESET=$CMAKE_PRESET --build-arg BUILD_VERSION=standalone --build-arg UBUNTU_VERSION="${{ matrix.os }}" $BUILD_ARGS
+        echo "::endgroup::"
+
+        echo "::group::Check docker image size"
+        docker inspect -f "{{ .Size }}" $CONTAINER_FULL_NAME | numfmt --to=si
+        echo "::endgroup::"
+
+    - name: 'Docker: Push Standalone Release (public repositories)'
+      if: ${{ inputs.push }}
+      shell: bash
+      run: |
+        docker push $CONTAINER_FULL_NAME
+
+    - name: Free Disk Space (Ubuntu)
+      if: ${{ inputs.free-disk-space }}
+      uses: jlumbroso/free-disk-space@main
+
+    - name: Configure devcontainer env
+      shell: bash
+      run: |
+        echo "DEVCONTAINER_NAME=${{ inputs.container-repository }}" >> $GITHUB_ENV
+        echo "DEVCONTAINER_TAG=${{ matrix.os }}-devcontainer-${{ env.RELEASE_TAG }}" >> $GITHUB_ENV
+        echo "DEVCONTAINER_FULL_NAME=$CONTAINER_NAME:${{ matrix.os }}-devcontainer-${{ env.RELEASE_TAG }}" >> $GITHUB_ENV
+        echo "BUILD_VERSION=devcontainer" >> $GITHUB_ENV
+        echo "UBUNTU_VERSION=${{ matrix.os }}" >> $GITHUB_ENV
+
+    # - name: Build devcontainer image
+    #   shell: bash
+    #   run: |
+    #     echo "::group::Build devcontainer image $DEVCONTAINER_FULL_NAME"
+    #     devcontainer build --workspace-folder . \
+    #       --image-name $DEVCONTAINER_FULL_NAME \
+    #       $SSH_OPT \
+    #       --build-arg CMAKE_PRESET=$CMAKE_PRESET \
+    #       --build-arg BUILD_VERSION=standalone \
+    #       --build-arg UBUNTU_VERSION="${{ matrix.os }}" \
+    #       $BUILD_ARGS
+    #     echo "::endgroup::"
+    #
+    #     echo "::group::Check devcontainer's docker image size $DEVCONTAINER_FULL_NAME"
+    #     docker images
+    #     docker ps
+    #     docker inspect -f "{{ .Size }}" $DEVCONTAINER_FULL_NAME | numfmt --to=si
+    #     echo "::endgroup::"
+    #
+    #     echo "::group::Push devcontainer image $DEVCONTAINER_FULL_NAME"
+    #     if [ ${{ inputs.push }} ]; then
+    #       echo "Pushing the image to $DEVCONTAINER_FULL_NAME"
+    #       docker push $DEVCONTAINER_FULL_NAME
+    #     else
+    #       echo "Push skipped for $DEVCONTAINER_FULL_NAME"
+    #     fi
+    #     echo "::endgroup::"
+
+
+    - name: Build and push dev container image
+      uses: devcontainers/ci@v0.3
+      with:
+        imageName: ${{ env.DEVCONTAINER_NAME}}
+        imageTag: ${{ env.DEVCONTAINER_TAG }}
+        subFolder: .github/devcontainer/${{ matrix.os }}
+        configFile: .github/devcontainer/${{ matrix.os }}/devcontainer.json
+        push: ${{ inputs.push && 'always' || 'never' }}
+
+    - name: 'Docker: Check devcontainer size'
+      shell: bash
+      run: |
+        docker images
+        docker ps
+        docker inspect -f "{{ .Size }}" $DEVCONTAINER_FULL_NAME | numfmt --to=si

--- a/.github/workflows/superbuild-devcontainer.yml
+++ b/.github/workflows/superbuild-devcontainer.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: true
 
+      build-standalone-devel:
+        type: boolean
+        required: false
+        default: true
+
       build-devcontainer:
         type: boolean
         required: false
@@ -205,6 +210,40 @@ jobs:
       shell: bash
       run: |
         docker push $CONTAINER_FULL_NAME
+
+    - name: Free Disk Space (Ubuntu)
+      if: ${{ inputs.free-disk-space && inputs.build-devcontainer}}
+      uses: jlumbroso/free-disk-space@main
+
+    - name: 'Docker: Build Standalone Devel'
+      if: ${{ inputs.build-standalone-devel }}
+      env:
+        CONTAINER_TAG: ${{ matrix.os }}-standalone-devel-${{ env.RELEASE_TAG }}
+      shell: bash
+      run: |
+        echo "::group::Prepare docker"
+
+        CONTAINER_FULL_NAME_DEVEL=$CONTAINER_NAME:$CONTAINER_TAG
+        echo "CONTAINER_FULL_NAME_DEVEL=$CONTAINER_FULL_NAME_DEVEL" >> $GITHUB_ENV
+        echo "::endgroup::"
+
+        echo "::group::Print Dockerfile"
+        cat .github/devcontainer/Dockerfile
+        echo "::endgroup::"
+
+        echo "::group::Build Dockerfile"
+        docker build . -f .github/devcontainer/Dockerfile $SSH_OPT --tag $CONTAINER_FULL_NAME_DEVEL --build-arg CMAKE_PRESET=$CMAKE_PRESET --build-arg BUILD_VERSION=standalone-devel --build-arg UBUNTU_VERSION="${{ matrix.os }}" $BUILD_ARGS
+        echo "::endgroup::"
+
+        echo "::group::Check docker image size"
+        docker inspect -f "{{ .Size }}" $CONTAINER_FULL_NAME_DEVEL | numfmt --to=si
+        echo "::endgroup::"
+
+    - name: 'Docker: Push Standalone Devel (public repositories)'
+      if: ${{ inputs.build-standalone-devel && inputs.push }}
+      shell: bash
+      run: |
+        docker push $CONTAINER_FULL_NAME_DEVEL
 
     - name: Free Disk Space (Ubuntu)
       if: ${{ inputs.free-disk-space && inputs.build-devcontainer}}

--- a/.github/workflows/superbuild-devcontainer.yml
+++ b/.github/workflows/superbuild-devcontainer.yml
@@ -26,6 +26,12 @@ on:
         required: false
         default: relwithdebinfo
 
+      include-preset-in-name:
+        type: boolean
+        required: false
+        default: false
+        description: "Whether to include the preset name in the container name"
+
       custom-entrypoint-standalone:
         type: string
         required: false
@@ -180,12 +186,19 @@ jobs:
         echo "CMAKE_PRESET: $CMAKE_PRESET"
         echo "CMAKE_PRESET=$CMAKE_PRESET" >> $GITHUB_ENV
         echo "UBUNTU_VERSION=${{ matrix.os }}" >> $GITHUB_ENV
+        
+        # Create tag suffix with optional preset inclusion
+        TAG_SUFFIX="${{ env.RELEASE_TAG }}"
+        if [ "${{ inputs.include-preset-in-name }}" = "true" ]; then
+          TAG_SUFFIX="$CMAKE_PRESET-$TAG_SUFFIX"
+        fi
+        echo "TAG_SUFFIX=$TAG_SUFFIX" >> $GITHUB_ENV
 
     - name: 'Docker: Build Standalone Images (Release + Devel)'
       if: ${{ inputs.build-standalone-release || inputs.build-standalone-devel }}
       env:
-        CONTAINER_TAG_RELEASE: ${{ matrix.os }}-standalone-release-${{ env.RELEASE_TAG }}
-        CONTAINER_TAG_DEVEL: ${{ matrix.os }}-standalone-devel-${{ env.RELEASE_TAG }}
+        CONTAINER_TAG_RELEASE: ${{ matrix.os }}-standalone-release-${{ env.TAG_SUFFIX }}
+        CONTAINER_TAG_DEVEL: ${{ matrix.os }}-standalone-devel-${{ env.TAG_SUFFIX }}
       shell: bash
       run: |
         echo "::group::Prepare docker"
@@ -237,6 +250,7 @@ jobs:
         fi
         echo "::endgroup::"
 
+
     - name: 'Docker: Push Standalone Images'
       if: ${{ (inputs.build-standalone-release || inputs.build-standalone-devel) && inputs.push }}
       shell: bash
@@ -274,8 +288,8 @@ jobs:
       shell: bash
       run: |
         echo "DEVCONTAINER_NAME=${{ inputs.container-repository }}" >> $GITHUB_ENV
-        echo "DEVCONTAINER_TAG=${{ matrix.os }}-devcontainer-${{ env.RELEASE_TAG }}" >> $GITHUB_ENV
-        echo "DEVCONTAINER_FULL_NAME=$CONTAINER_NAME:${{ matrix.os }}-devcontainer-${{ env.RELEASE_TAG }}" >> $GITHUB_ENV
+        echo "DEVCONTAINER_TAG=${{ matrix.os }}-devcontainer-${{ env.TAG_SUFFIX }}" >> $GITHUB_ENV
+        echo "DEVCONTAINER_FULL_NAME=$CONTAINER_NAME:${{ matrix.os }}-devcontainer-${{ env.TAG_SUFFIX }}" >> $GITHUB_ENV
 
     - name: 'Docker: Build Devcontainer Image'
       if: ${{ inputs.build-devcontainer }}

--- a/.github/workflows/superbuild-devcontainer.yml
+++ b/.github/workflows/superbuild-devcontainer.yml
@@ -25,6 +25,16 @@ on:
         default: ''
         description: 'Space-separated list of build-arg for docker. Ex "BUILD_VERSION=standalone KEEP_INSTALL=false"'
 
+      build-standalone:
+        type: boolean
+        required: false
+        default: true
+
+      build-devcontainer:
+        type: boolean
+        required: false
+        default: true
+
       repository:
         type: string
         description: "path to the superbuild repository to clone and package"
@@ -68,7 +78,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [jammy, noble]
+        # os: [jammy, noble]
+        os: [jammy]
     env:
       SSH_KEY: ${{ secrets.SSH_KEY }}
 
@@ -94,10 +105,6 @@ jobs:
           echo "SSH_AUTH_SOCK = ${{ env.SSH_AUTH_SOCK }}"
           ssh-add -l
 
-    - name: Free Disk Space (Ubuntu)
-      if: ${{ inputs.free-disk-space }}
-      uses: jlumbroso/free-disk-space@main
-
     - name: Clone superbuild repository
       uses: actions/checkout@v4
       with:
@@ -106,17 +113,9 @@ jobs:
         ref: ${{ inputs.branch }}
         ssh-key: ${{ env.SSH_KEY }}
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 'latest'
-
-    - name: Upgrade NPM
-      shell: bash
-      run: npm install -g npm@latest
-
-    - name: Check NPM Version
-      run: npm -v
+    - name: Free Disk Space (Ubuntu)
+      if: ${{ inputs.free-disk-space }}
+      uses: jlumbroso/free-disk-space@main
 
     - name: Check docker
       shell: bash
@@ -141,13 +140,19 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: 'Docker: Build Standalone Release'
+    - name: Setup common docker build options
+      shell: bash
       env:
         CONTAINER_NAME: ${{ inputs.container-repository }}
-        CONTAINER_TAG: ${{ matrix.os }}-standalone-${{ env.RELEASE_TAG }}
-      shell: bash
       run: |
-        echo "::group::Prepare docker"
+        echo "CONTAINER_NAME: $CONTAINER_NAME"
+        echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
+
+        if [ "${{ env.SSH_KEY }}" != '' ]; then
+          SSH_OPT="--ssh default"
+          echo "SSH_OPT=$SSH_OPT"
+          echo "SSH_OPT=$SSH_OPT" >> $GITHUB_ENV;
+        fi
         CMAKE_PRESET="${{ inputs.preset }}"
         if [ "${{ matrix.os }}" = "noble" ]; then
           echo "os is noble"
@@ -157,14 +162,16 @@ jobs:
         fi
         echo "CMAKE_PRESET: $CMAKE_PRESET"
         echo "CMAKE_PRESET=$CMAKE_PRESET" >> $GITHUB_ENV
+        echo "UBUNTU_VERSION=${{ matrix.os }}" >> $GITHUB_ENV
 
-        if [ "${{ env.SSH_KEY }}" != '' ]; then
-          SSH_OPT='--ssh default'
-          echo "SSH_OPT=$SSH_OPT"
-          echo "SSH_OPT='--ssh default'" >> $GITHUB_ENV;
-        fi
-        echo "CONTAINER_NAME: $CONTAINER_NAME"
-        echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
+    - name: 'Docker: Build Standalone Release'
+      if: ${{ inputs.build-standalone }}
+      env:
+        CONTAINER_TAG: ${{ matrix.os }}-standalone-${{ env.RELEASE_TAG }}
+      shell: bash
+      run: |
+        echo "::group::Prepare docker"
+
         CONTAINER_FULL_NAME=$CONTAINER_NAME:$CONTAINER_TAG
         echo "CONTAINER_FULL_NAME=$CONTAINER_FULL_NAME" >> $GITHUB_ENV
         echo "::endgroup::"
@@ -194,54 +201,45 @@ jobs:
         echo "::endgroup::"
 
     - name: 'Docker: Push Standalone Release (public repositories)'
-      if: ${{ inputs.push }}
+      if: ${{ inputs.build-standalone && inputs.push }}
       shell: bash
       run: |
         docker push $CONTAINER_FULL_NAME
 
     - name: Free Disk Space (Ubuntu)
-      if: ${{ inputs.free-disk-space }}
+      if: ${{ inputs.free-disk-space && inputs.build-devcontainer}}
       uses: jlumbroso/free-disk-space@main
 
+    - name: Setup Node.js
+      if: ${{ inputs.build-devcontainer }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: 'latest'
+
+    - name: Upgrade NPM
+      if: ${{ inputs.build-devcontainer }}
+      shell: bash
+      run: |
+        npm install -g npm@latest
+        echo "Checking NPM vesion"
+        npm -v
+
     - name: Configure devcontainer env
+      if: ${{ inputs.build-devcontainer }}
       shell: bash
       run: |
         echo "DEVCONTAINER_NAME=${{ inputs.container-repository }}" >> $GITHUB_ENV
         echo "DEVCONTAINER_TAG=${{ matrix.os }}-devcontainer-${{ env.RELEASE_TAG }}" >> $GITHUB_ENV
         echo "DEVCONTAINER_FULL_NAME=$CONTAINER_NAME:${{ matrix.os }}-devcontainer-${{ env.RELEASE_TAG }}" >> $GITHUB_ENV
         echo "BUILD_VERSION=devcontainer" >> $GITHUB_ENV
-        echo "UBUNTU_VERSION=${{ matrix.os }}" >> $GITHUB_ENV
-
-    # - name: Build devcontainer image
-    #   shell: bash
-    #   run: |
-    #     echo "::group::Build devcontainer image $DEVCONTAINER_FULL_NAME"
-    #     devcontainer build --workspace-folder . \
-    #       --image-name $DEVCONTAINER_FULL_NAME \
-    #       $SSH_OPT \
-    #       --build-arg CMAKE_PRESET=$CMAKE_PRESET \
-    #       --build-arg BUILD_VERSION=standalone \
-    #       --build-arg UBUNTU_VERSION="${{ matrix.os }}" \
-    #       $BUILD_ARGS
-    #     echo "::endgroup::"
-    #
-    #     echo "::group::Check devcontainer's docker image size $DEVCONTAINER_FULL_NAME"
-    #     docker images
-    #     docker ps
-    #     docker inspect -f "{{ .Size }}" $DEVCONTAINER_FULL_NAME | numfmt --to=si
-    #     echo "::endgroup::"
-    #
-    #     echo "::group::Push devcontainer image $DEVCONTAINER_FULL_NAME"
-    #     if [ ${{ inputs.push }} ]; then
-    #       echo "Pushing the image to $DEVCONTAINER_FULL_NAME"
-    #       docker push $DEVCONTAINER_FULL_NAME
-    #     else
-    #       echo "Push skipped for $DEVCONTAINER_FULL_NAME"
-    #     fi
-    #     echo "::endgroup::"
-
+        if [ "${{ env.SSH_KEY }}" != '' ]; then
+          SSH_OPT="--ssh=default"
+          echo "SSH_OPT=$SSH_OPT"
+          echo "SSH_OPT=$SSH_OPT" >> $GITHUB_ENV;
+        fi
 
     - name: Build and push dev container image
+      if: ${{ inputs.build-devcontainer }}
       uses: devcontainers/ci@v0.3
       with:
         imageName: ${{ env.DEVCONTAINER_NAME}}
@@ -251,6 +249,7 @@ jobs:
         push: ${{ inputs.push && 'always' || 'never' }}
 
     - name: 'Docker: Check devcontainer size'
+      if: ${{ inputs.build-devcontainer }}
       shell: bash
       run: |
         docker images


### PR DESCRIPTION
This PR adds a reusable workflow to enable easy packaging of mc-rtc-superbuild environments. To use it you will need:
- A fork or a branch of mc-rtc-superbuild set-up to build what  you wish to package
- A github action that uses this reusable workflow. It only needs to provide:
  - the repository org/name and branch
  - a cmake preset to build
  - the container registry to push the package to (ghcr.io/your-org/project)
  - for packaging private repositories you need to provide and `SSH_KEY` secret with the appropriate permissions to pull all the dependencies.
  
 - This was tested to package the CDADance demo and choreonoid.
  
- For example see https://github.com/isri-aist/mc-rtc-superbuild-private-ci/

```yaml
name: Package CDADance Demo
on:
  repository_dispatch:
    types:
    - dispatch-cdadance
  push:
    branches:
      - '**'
  pull_request:
    branches:
      - '**'

jobs:
  # test
  package-devcontainers:
    strategy:
      matrix:
        preset:
          - cdadance-demo-auto
          - cdadance-demo-manual
          - cdadance-simu-auto
          - cdadance-simu-manual
        os:
         - jammy
    uses: arntanguy/github-actions/.github/workflows/superbuild-devcontainer.yml@topic/devcontainer
    with:
      runner: self-hosted
      os: ${{ matrix.os }}
      free-disk-space: false
      preset: ${{ matrix.preset }}
      include-preset-in-name: true
      repository: isri-aist/cdadance-superbuild
      image-source-repo: ${{ github.repository }}
      branch: main
      container-repository: ghcr.io/isri-aist/cdadance
      # On dispatch, if there is a tag payload, do a release
      # otherwise we use latest tag
      release-tag: ${{ github.event.client_payload.tag }}
      push: true
    secrets:
      SSH_KEY: ${{ secrets.SSH_KEY }}

```